### PR TITLE
Fix installation log message

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -140,7 +140,7 @@ install_exists() {
         ui_print " [INFO] Skipping installation checks."
         install_done
     else
-        ui_print " [INFO] No previous installation installation found."
+        ui_print " [INFO] No previous installation found."
         ui_print " [INFO] Going for initial *installation*."
     fi
 }


### PR DESCRIPTION
## Summary
- correct info message when no previous install is found

## Testing
- `./tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bef9cf3fc8325a60d6dc733ff67a9