### PR TITLE
Add shellcheck workflow and lint fixes

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: Shellcheck
+
+on:
+  push:
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yml'
+  pull_request:
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yml'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: shellcheck $(git ls-files '*.sh')

--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -27,7 +27,9 @@ mount /data 2>/dev/null
 
 [ -f /data/adb/magisk/util_functions.sh ] || require_new_magisk
 . /data/adb/magisk/util_functions.sh
-[ $MAGISK_VER_CODE -lt 20400 ] && require_new_magisk
+if [ "$MAGISK_VER_CODE" -lt 20400 ]; then
+  require_new_magisk
+fi
 
 install_module
 exit 0

--- a/build-tools/debug-unmount.sh
+++ b/build-tools/debug-unmount.sh
@@ -15,11 +15,11 @@ error_add() {
 # unmount_file()
 #   Unmount target
 #
-# %usage: unmount_file source_path target_path
+# %usage: unmount_file target_path
 # parameters
-#   destination_path - Destination file path
+#   target_path - Destination file path to unmount
 unmount_file() {
-    uf_destination_path="$2"
+    uf_destination_path="$1"
 
     echo " [INFO] Unmounting."
     if umount "$uf_destination_path"; then

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -220,9 +220,9 @@ file_prepend_value_to_property() {
     favtp_filepath="$1"
     favtp_property="$2"
     favtp_value="$3"
-    
+
     echo " [INFO] Setting file '$favtp_filepath' property '$favtp_property' value '$favtp_value' directly now." >> "$logfile"
-    if sed -i -E "s/$favtp_property=/&$fsp_value/" "$fsp_filepath"
+    if sed -i -E "s/$favtp_property=/&$favtp_value/" "$favtp_filepath"
     then
         echo " [INFO] File property was set successfully." >> "$logfile"
     else
@@ -249,7 +249,7 @@ file_prepend_value_to_property_wrapper() {
         file_clear_property "$favtpw_filepath" "$favtpw_property"
         if file_is_property_clean "$favtpw_filepath" "$favtpw_property"; then
             if ! is_empty "$favtpw_value"; then
-                file_prepend_value_to_property "$favtpw_filepath" "$fspw_property" "$favtpw_value"
+                file_prepend_value_to_property "$favtpw_filepath" "$favtpw_property" "$favtpw_value"
                 return 0
             else
                 echo " [INFO] No value was set due to parameters." >> "$logfile"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -54,7 +54,7 @@ PROP
 assert_return 0 file_set_property_wrapper /tmp/test.prop prop value
 grep -q 'prop=value' /tmp/test.prop && echo "PASSED: property set" || { echo "FAILED: property not set"; failure=1; }
 
-if [ $failure -eq 0 ]; then
+if [ "$failure" -eq 0 ]; then
   echo "All tests passed"
 else
   echo "Some tests failed"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run ShellCheck on `.sh` files
- clean up shell script lint issues

## Testing
- `bash -n customize.sh && echo customize OK`
- `bash -n post-fs-data.sh && echo pfsd OK`
- `bash -n build-tools/debug-unmount.sh && echo unmount OK`
- `bash -n build-tools/build-create-module.sh && echo create OK`
- `bash -n build-tools/build-delete-module.sh && echo delete OK`
- `bash -n tests/run-tests.sh && echo tests OK`
- `bash -n META-INF/com/google/android/update-binary && echo update OK`
- `tests/run-tests.sh >/tmp/test.log && tail -n 20 /tmp/test.log`
- `apt-get install -y shellcheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_685bf952e7348325a4d7118fd665e5ba