### PR TITLE
Ensure consistent XML key usage

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -14,7 +14,7 @@ module_path="/data/adb/modules"
 floating_feature_xml_file="floating_feature.xml"
 floating_feature_xml_dir="/system/etc/"
 floating_feature_xml_fullpath="$floating_feature_xml_dir$floating_feature_xml_file"
-floating_feature_xml_dex_key="<SEC_FLOATING_FEATURE_COMMON_CONFIG_DEX_MODE>"
+floating_feature_xml_dex_key="SEC_FLOATING_FEATURE_COMMON_CONFIG_DEX_MODE"
 floating_feature_xml_dex_key_value="standalone"
 floating_feature_xml_patched_file="floating_feature.xml.patched"
 floating_feature_xml_patched_fullpath="$module_path/$module_name/$floating_feature_xml_patched_file"
@@ -56,7 +56,7 @@ file_key_exists() {
     fke_filepath="$1"
     fke_key="$2"
 
-    if grep -q "$fke_key" "$fke_filepath"; then
+    if grep -q "<$fke_key" "$fke_filepath"; then
         ui_print " [INFO] Key '$fke_key' exists inside '$fke_filepath'."
         return 0
     else

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # magisk-samsung-dex-standalone-mode
 
-Magisk module to systemlessly enable Samsung DeX standalone mode by patching `floating_feature.xml`, it adds `standalone` value to `<SEC_FLOATING_FEATURE_COMMON_CONFIG_DEX_MODE>` key.
+Magisk module to systemlessly enable Samsung DeX standalone mode by patching `floating_feature.xml`, it adds `standalone` value to `SEC_FLOATING_FEATURE_COMMON_CONFIG_DEX_MODE` key.
 
 ✅ Enables DeX standalone mode on supported phones.
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -42,8 +42,8 @@ rm /tmp/fileexists
 assert_return 1 filepath_exists /tmp/fileexists
 
 echo '<a>bar</a>' > /tmp/test.xml
-assert_return 0 file_key_exists /tmp/test.xml '<a>'
-assert_return 1 file_key_exists /tmp/test.xml '<b>'
+assert_return 0 file_key_exists /tmp/test.xml a
+assert_return 1 file_key_exists /tmp/test.xml b
 
 assert_return 0 is_empty ''
 assert_return 1 is_empty 'abc'


### PR DESCRIPTION
## Summary
- use the plain key name for `floating_feature_xml_dex_key`
- adjust `file_key_exists` lookup
- update README and unit tests

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c051d9e208325a13aaac3a9129fa8