### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10,11 +10,15 @@ abort() { return 1; }
 chcon() { true; }
 
 # Source scripts without executing main
+# Generate temporary versions of the sourced scripts without their final lines
 sed '$d' post-fs-data.sh > /tmp/pfsd.sh
+# shellcheck source=/tmp/pfsd.sh disable=SC1091
 . /tmp/pfsd.sh
 sed '$d' customize.sh > /tmp/customize.sh
+# shellcheck source=/tmp/customize.sh disable=SC1091
 . /tmp/customize.sh
 sed '$d' build-tools/debug-unmount.sh > /tmp/debug-unmount.sh
+# shellcheck source=/tmp/debug-unmount.sh disable=SC1091
 . /tmp/debug-unmount.sh
 
 logfile="/tmp/test.log"
@@ -52,32 +56,57 @@ cat > /tmp/test.prop <<PROP
 prop=
 PROP
 assert_return 0 file_set_property_wrapper /tmp/test.prop prop value
-grep -q 'prop=value' /tmp/test.prop && echo "PASSED: property set" || { echo "FAILED: property not set"; failure=1; }
+if grep -q 'prop=value' /tmp/test.prop; then
+  echo "PASSED: property set"
+else
+  echo "FAILED: property not set"
+  failure=1
+fi
 
 # Test XML utilities
 cat > /tmp/xml_add.xml <<EOF
 <a>foo</a>
 EOF
 assert_return 0 file_add_xml_key_value /tmp/xml_add.xml a bar
-grep -q '<a>foo,bar</a>' /tmp/xml_add.xml && echo "PASSED: add xml key value" || { echo "FAILED: add xml key value"; failure=1; }
+if grep -q '<a>foo,bar</a>' /tmp/xml_add.xml; then
+  echo "PASSED: add xml key value"
+else
+  echo "FAILED: add xml key value"
+  failure=1
+fi
 
 cat > /tmp/xml_remove.xml <<EOF
 <a>foo,bar,baz</a>
 EOF
 assert_return 0 file_remove_xml_key_value /tmp/xml_remove.xml a bar
-grep -q '<a>foo,baz</a>' /tmp/xml_remove.xml && echo "PASSED: remove xml key value" || { echo "FAILED: remove xml key value"; failure=1; }
+if grep -q '<a>foo,baz</a>' /tmp/xml_remove.xml; then
+  echo "PASSED: remove xml key value"
+else
+  echo "FAILED: remove xml key value"
+  failure=1
+fi
 
 cat > /tmp/xml_commas.xml <<EOF
 <a>foo,</a>
 EOF
 assert_return 0 file_remove_xml_key_commas /tmp/xml_commas.xml a
-grep -q '<a>foo</a>' /tmp/xml_commas.xml && echo "PASSED: remove xml key commas" || { echo "FAILED: remove xml key commas"; failure=1; }
+if grep -q '<a>foo</a>' /tmp/xml_commas.xml; then
+  echo "PASSED: remove xml key commas"
+else
+  echo "FAILED: remove xml key commas"
+  failure=1
+fi
 
 cat > /tmp/xml_orig.xml <<EOF
 <a>foo</a>
 EOF
 assert_return 0 file_set_xml_key /tmp/xml_orig.xml /tmp/xml_patched.xml a bar
-grep -q '<a>foo,bar</a>' /tmp/xml_patched.xml && echo "PASSED: set xml key" || { echo "FAILED: set xml key"; failure=1; }
+if grep -q '<a>foo,bar</a>' /tmp/xml_patched.xml; then
+  echo "PASSED: set xml key"
+else
+  echo "FAILED: set xml key"
+  failure=1
+fi
 
 if [ "$failure" -eq 0 ]; then
   echo "All tests passed"


### PR DESCRIPTION
## Summary
- silence shellcheck sourcing warnings in the test suite
- rewrite test assertions to avoid `&&`/`||` chain

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c0af6f0088325ba7e194e6f495dcb