### PR TITLE
Add strict mode to scripts

### DIFF
--- a/build-tools/debug-unmount.sh
+++ b/build-tools/debug-unmount.sh
@@ -1,4 +1,5 @@
 #!/system/bin/sh
+set -euo pipefail
 
 # Unmount variables
 floating_feature_xml_patched_file="floating_feature.xml.patched"

--- a/customize.sh
+++ b/customize.sh
@@ -1,4 +1,5 @@
 #!/system/bin/sh
+set -euo pipefail
 
 #
 # *********************************

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -1,4 +1,5 @@
 #!/system/bin/sh
+set -euo pipefail
 
 # General variables
 module_name="samsung-dex-standalone-mode"


### PR DESCRIPTION
## Summary
- use `set -euo pipefail` in customize.sh
- use `set -euo pipefail` in post-fs-data.sh
- use `set -euo pipefail` in build-tools/debug-unmount.sh

## Testing
- `bash tests/run-tests.sh`
- `shellcheck $(git ls-files '*.sh')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3a0c6558832586cc2827d9303dc3