### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build module
+        run: bash build-tools/build-create-module.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: magisk-samsung-dex-standalone-mode
+          path: magisk-samsung-dex-standalone-mode.zip
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: magisk-samsung-dex-standalone-mode.zip

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,11 @@ make test
 ```
 
 Tests are also executed automatically in the CI pipeline.
+
+## Release workflow
+
+A GitHub Actions workflow builds the module whenever a tag is pushed or a release is published. The resulting `magisk-samsung-dex-standalone-mode.zip` is saved as a workflow artifact and attached to the release.
+
 ## Manual installation
 
 After building the ZIP you can install it directly with Magisk:


### PR DESCRIPTION
## Summary
- add a workflow triggered by tag pushes or release publication
- document the release workflow in the README

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c39d7d01c832597559ff5fad1717d