### PR TITLE
Add lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test
+.PHONY: build clean test lint
 
 build:
 	bash build-tools/build-create-module.sh
@@ -8,3 +8,6 @@ clean:
 
 test:
 	bash tests/run-tests.sh
+
+lint:
+	shellcheck $(git ls-files '*.sh')

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ A `Makefile` is also provided for convenience with the targets:
 `make build` - create the ZIP module.
 `make clean` - remove the generated module.
 `make test` - run the shell tests.
+`make lint` - run shellcheck on all scripts.
 
 Testing/debug related:
 
@@ -68,6 +69,10 @@ Run the shell based tests from the repository root with:
 
 ```bash
 make test
+```
+Lint all shell scripts with:
+```bash
+make lint
 ```
 
 Tests are also executed automatically in the CI pipeline.


### PR DESCRIPTION
## Summary
- add a `lint` Makefile target that runs shellcheck
- document the new target in the Makefile section
- mention lint instructions in the Testing section

## Testing
- `make lint` *(fails: `shellcheck` not found)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c6a403f9c8325887a13a5b4795ae6