### PR TITLE
Fix zip creation paths

### DIFF
--- a/build-tools/build-create-module.bat
+++ b/build-tools/build-create-module.bat
@@ -33,7 +33,7 @@ if exist "%ZIPFILE%" (
 set "FILELIST="
 echo Preparing file list.
 for /f "delims=" %%i in (%LISTFILE%) do (
-    set "FILELIST=!FILELIST! '%CD%\%%i',"
+    set "FILELIST=!FILELIST! '%%i',"
 )
 
 :: Remove the leading comma and space if they exist
@@ -50,7 +50,7 @@ if "!FILELIST:~-1!" == "," (
 :: Execute PowerShell to create the ZIP file
 echo Creating ZIP module.
 powershell -NoProfile -ExecutionPolicy Bypass ^
-  "Compress-Archive -Path @(%FILELIST%) -DestinationPath '%CD%\%ZIPFILE%' -Force"
+  "Compress-Archive -Path @(%FILELIST%) -DestinationPath '%ZIPFILE%' -Force"
 if not exist "%ZIPFILE%" (
     echo Failed to create ZIP module, "%ZIPFILE%".
     goto quit_with_error

--- a/build-tools/build-create-module.sh
+++ b/build-tools/build-create-module.sh
@@ -30,7 +30,7 @@ fi
 FILELIST=()
 echo Preparing file list.
 while IFS= read -r line; do
-    FILELIST+=("${PWD}/${line}")
+    FILELIST+=("${line}")
 done < "${LISTFILE}"
 
 # Execute zip command to create the ZIP file


### PR DESCRIPTION
## Summary
- preserve relative paths when creating module ZIP

## Testing
- `bash tests/run-tests.sh`
- `shellcheck $(git ls-files '*.sh')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdbedb63083258f8d21c193daba4a