### PR TITLE
Add CI packaging test and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,17 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run shell tests
         run: bash tests/run-tests.sh
+  package:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Verify ZIP creation
+        run: bash tests/test-build-create-module.sh
+  package-windows:
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Verify ZIP creation on Windows
+        run: pwsh tests/test-build-create-module.ps1

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Magisk module to systemlessly enable Samsung DeX standalone mode by patching `fl
 [![GitHub Stars](https://img.shields.io/github/stars/supermarsx/magisk-samsung-dex-standalone-mode?style=flat-square&label=Stars)](#)
 [![GitHub Forks](https://img.shields.io/github/forks/supermarsx/magisk-samsung-dex-standalone-mode?style=flat-square&label=Forks)](#)
 [![GitHub Watchers](https://img.shields.io/github/watchers/supermarsx/magisk-samsung-dex-standalone-mode?style=flat-square&label=Watchers)](#)
+[![Build Status](https://github.com/supermarsx/magisk-samsung-dex-standalone-mode/actions/workflows/ci.yml/badge.svg)](https://github.com/supermarsx/magisk-samsung-dex-standalone-mode/actions/workflows/ci.yml)
 [![GitHub repo size](https://img.shields.io/github/repo-size/supermarsx/magisk-samsung-dex-standalone-mode?style=flat-square&label=Repo%20Size)](#)
 [![GitHub Downloads](https://img.shields.io/github/downloads/supermarsx/magisk-samsung-dex-standalone-mode/total.svg?style=flat-square&label=Downloads)](https://codeload.github.com/supermarsx/magisk-samsung-dex-standalone-mode/zip/refs/heads/main)
 [![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/supermarsx/magisk-samsung-dex-standalone-mode?style=flat-square&label=Issues)](#)

--- a/tests/test-build-create-module.ps1
+++ b/tests/test-build-create-module.ps1
@@ -1,0 +1,41 @@
+# PowerShell build test for Windows
+$ErrorActionPreference = 'Stop'
+
+# Create temporary workspace
+$TmpDir = New-Item -ItemType Directory -Path ([System.IO.Path]::GetTempPath()) -Name ([System.IO.Path]::GetRandomFileName())
+Copy-Item -Recurse . "$TmpDir\repo"
+Set-Location "$TmpDir\repo"
+
+# Provide required files for build script
+Copy-Item build-tools\build-filelist.txt build-filelist.txt
+Copy-Item build-tools\debug-unmount.sh debug-unmount.sh
+
+cmd /c build-tools\build-create-module.bat
+
+$ZipFile = "magisk-samsung-dex-standalone-mode.zip"
+if (-not (Test-Path $ZipFile)) {
+    Write-Host "ZIP not created"
+    exit 1
+}
+
+$Extract = Join-Path $Pwd 'extract'
+Expand-Archive -Path $ZipFile -DestinationPath $Extract -Force
+
+$RequiredPaths = @(
+    'META-INF/com/google/android/update-binary',
+    'META-INF/com/google/android/update-script',
+    'customize.sh',
+    'module.prop',
+    'post-fs-data.sh',
+    'skip_mount',
+    'debug-unmount.sh',
+    'update.json'
+)
+foreach ($path in $RequiredPaths) {
+    if (-not (Test-Path (Join-Path $Extract $path))) {
+        Write-Host "Missing $path"
+        exit 1
+    }
+}
+
+Write-Host "build-create-module windows test passed"


### PR DESCRIPTION
## Summary
- add GitHub Actions status badge to README
- verify packaging in CI
- add Windows packaging test

## Testing
- `make lint` *(fails: shellcheck not installed)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685cde1c6d2c8325935dc4e4fe7f6a46