### PR TITLE
Fix comment for increment_error_count

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -19,7 +19,7 @@ error_count=0
 error_message=""
 logfile="$module_log_file_fullpath"
 
-# error_count_up()
+# increment_error_count()
 #   Increase error count
 increment_error_count() {
     echo " [INFO] Incrementing error by 1." >> "$logfile"


### PR DESCRIPTION
## Summary
- ensure the comment above `increment_error_count()` reflects its name

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861131885848325848290525c19baf6