### PR TITLE
Fix shellcheck issues

### DIFF
--- a/build-tools/debug-unmount.sh
+++ b/build-tools/debug-unmount.sh
@@ -1,8 +1,7 @@
 #!/system/bin/sh
-set -euo pipefail
+set -eu
 
 # Unmount variables
-floating_feature_xml_patched_file="floating_feature.xml.patched"
 floating_feature_xml_original_fullpath="/system/etc/floating_feature.xml"
 
 # error_add()

--- a/customize.sh
+++ b/customize.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-set -euo pipefail
+set -eu
 
 #
 # *********************************

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-set -euo pipefail
+set -eu
 
 # General variables
 module_name="samsung-dex-standalone-mode"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -35,8 +35,12 @@ echo "description=" > "$module_prop_fullpath"
 
 # Environment for install_process tests
 module_path="/tmp/modules"
+module_name="samsung-dex-standalone-mode"
+floating_feature_xml_file="floating_feature.xml"
+floating_feature_xml_patched_file="floating_feature.xml.patched"
 floating_feature_xml_dir="/tmp/"
 floating_feature_xml_fullpath="${floating_feature_xml_dir}${floating_feature_xml_file}"
+# shellcheck disable=SC2034
 floating_feature_xml_original_fullpath="$floating_feature_xml_fullpath"
 floating_feature_xml_patched_fullpath="$module_path/$module_name/$floating_feature_xml_patched_file"
 mkdir -p "$(dirname "$floating_feature_xml_patched_fullpath")"


### PR DESCRIPTION
## Summary
- clean up `set -euo pipefail` usage
- drop unused variable in debug-unmount
- define missing variables in tests

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68612ed8fd64832587af43a70447e8c7