### PR TITLE
Add failure scenarios for install_process tests

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -337,14 +337,42 @@ fi
 # Test install_process behaviour
 touch "$floating_feature_xml_patched_fullpath"
 assert_return 0 install_process_wrapper
+
+# Scenario: floating feature file missing
 rm -f "$floating_feature_xml_patched_fullpath"
 rm -f "$MODPATH/remove"
 rm -f "$floating_feature_xml_fullpath"
 assert_return 1 install_process_wrapper
 if [ -f "$MODPATH/remove" ]; then
-  echo "PASSED: install abort path"
+  echo "PASSED: install abort missing file"
 else
-  echo "FAILED: install abort path"
+  echo "FAILED: install abort missing file"
+  failure=1
+fi
+rm -f "$MODPATH/remove"
+
+# Scenario: floating feature key missing
+cat > "$floating_feature_xml_fullpath" <<EOF
+<root></root>
+EOF
+assert_return 1 install_process_wrapper
+if [ -f "$MODPATH/remove" ]; then
+  echo "PASSED: install abort missing key"
+else
+  echo "FAILED: install abort missing key"
+  failure=1
+fi
+rm -f "$MODPATH/remove"
+
+# Scenario: floating feature already enabled
+cat > "$floating_feature_xml_fullpath" <<EOF
+<${floating_feature_xml_dex_key}>standalone</${floating_feature_xml_dex_key}>
+EOF
+assert_return 1 install_process_wrapper
+if [ -f "$MODPATH/remove" ]; then
+  echo "PASSED: install abort already enabled"
+else
+  echo "FAILED: install abort already enabled"
   failure=1
 fi
 


### PR DESCRIPTION
## Summary
- expand install tests to simulate missing floating feature file, missing key and key already enabled
- use temporary paths for floating feature xml

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686186a235d48325840276f9dc5c22b4