### PR TITLE
Add tests for post_fs_process

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -166,7 +166,8 @@ file_set_property() {
     fsp_value="$3"
     
     echo " [INFO] Setting file '$fsp_filepath' property '$fsp_property' value '$fsp_value' directly now." >> "$logfile"
-    if sed -i -E "s/$fsp_property=.*$/$fsp_property=$fsp_value/" "$fsp_filepath"
+    fsp_value_escaped=$(printf '%s' "$fsp_value" | sed 's/[\\/&]/\\&/g')
+    if sed -i -E "s@$fsp_property=.*@$fsp_property=$fsp_value_escaped@" "$fsp_filepath"
     then
         echo " [INFO] File property was set successfully." >> "$logfile"
     else


### PR DESCRIPTION
## Summary
- extend tests with `post_fs_process_wrapper`
- fake `mount` system call
- escape values in `file_set_property` to handle `/`
- verify success and failure cases for `post_fs_process`

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686186963bac8325b3af40743ca58ce5