### PR TITLE
Add shell safety options to build scripts

### DIFF
--- a/build-tools/build-create-module.sh
+++ b/build-tools/build-create-module.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Startup message
 echo Creating module.

--- a/build-tools/build-delete-module.sh
+++ b/build-tools/build-delete-module.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 echo Deleting ZIP module.
 


### PR DESCRIPTION
## Summary
- exit on failure in `build-create-module.sh`
- exit on failure in `build-delete-module.sh`

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861c6645c248325a0370680ce426251