### PR TITLE
Improve copy failure handling

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -379,7 +379,7 @@ file_set_xml_key() {
                 return 1   
             fi
         else
-            return 0
+            return 1
         fi
     else
         error_add "fileexists"


### PR DESCRIPTION
## Summary
- return an error when `file_copy` fails in `file_set_xml_key`
- simulate copy failure in test suite to verify failure path
- override `cp` command in tests to allow failure simulation

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861e156df248325a858d6b24b17d95d