### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -8,11 +8,17 @@ export MODPATH=/tmp/mod
 mkdir -p "$MODPATH"
 
 ui_print() { :; }
-abort() { return 1; }
+abort() {
+  return 1
+}
 chcon() { true; }
 set_perm_recursive() { true; }
-umount() { return "${UMOUNT_RC:-0}"; }
-mount() { return "${MOUNT_RC:-0}"; }
+umount() {
+  return "${UMOUNT_RC:-0}"
+}
+mount() {
+  return "${MOUNT_RC:-0}"
+}
 cp() {
   if [ "${CP_RC:-0}" -ne 0 ]; then
     return "$CP_RC"


### PR DESCRIPTION
## Summary
- expand minimal functions to multiline style

## Testing
- `shellcheck $(git ls-files '*.sh')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b804a37c83258f4872229dcdd072