### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2317
 set -e
 
 export logfile=/tmp/test.log
@@ -14,14 +15,14 @@ abort() {
 chcon() { true; }
 set_perm_recursive() { true; }
 umount() {
-  return "${UMOUNT_RC:-0}"
+  return ${UMOUNT_RC:-0}
 }
 mount() {
-  return "${MOUNT_RC:-0}"
+  return ${MOUNT_RC:-0}
 }
 cp() {
   if [ "${CP_RC:-0}" -ne 0 ]; then
-    return "$CP_RC"
+    return $CP_RC
   fi
   command cp "$@"
 }


### PR DESCRIPTION
## Summary
- suppress SC2317 warnings from shellcheck
- unquote return values in test helpers

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862b97ed11c8325bf3ebaec09016386