### PR TITLE
Fix shellcheck issues

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -15,14 +15,14 @@ abort() {
 chcon() { true; }
 set_perm_recursive() { true; }
 umount() {
-  return ${UMOUNT_RC:-0}
+  return "${UMOUNT_RC:-0}"
 }
 mount() {
-  return ${MOUNT_RC:-0}
+  return "${MOUNT_RC:-0}"
 }
 cp() {
   if [ "${CP_RC:-0}" -ne 0 ]; then
-    return $CP_RC
+    return "$CP_RC"
   fi
   command cp "$@"
 }


### PR DESCRIPTION
## Summary
- quote return codes in test helper script

## Testing
- `make test`
- `shellcheck $(git ls-files '*.sh')` *(fails: shellcheck not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bb9cb5388325b8ee809e3b36c602