### PR TITLE
Add version bump script and automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,7 @@ name: Build Release
 on:
   push:
     tags:
-      - '*'
-  release:
-    types: [published]
+      - 'v*'
 
 jobs:
   build:
@@ -19,8 +17,7 @@ jobs:
         with:
           name: magisk-samsung-dex-standalone-mode
           path: magisk-samsung-dex-standalone-mode.zip
-      - name: Upload release asset
-        if: github.event_name == 'release'
+      - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: magisk-samsung-dex-standalone-mode.zip

--- a/scripts/build-and-commit.sh
+++ b/scripts/build-and-commit.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+PROP_FILE="module.prop"
+JSON_FILE="update.json"
+
+# Determine current version components
+current_version=$(grep '^version=' "$PROP_FILE" | cut -d= -f2)
+current_year=${current_version%%.*}
+current_increment=${current_version##*.}
+current_year_now=$(date +%Y)
+
+if [ "$current_year_now" != "$current_year" ]; then
+  new_increment=1
+else
+  new_increment=$((current_increment + 1))
+fi
+
+new_version="${current_year_now}.${new_increment}"
+
+# Update module.prop
+sed -i -E "s/^version=.*/version=${new_version}/" "$PROP_FILE"
+sed -i -E "s/^versionCode=.*/versionCode=${new_increment}/" "$PROP_FILE"
+
+# Update update.json
+sed -i -E "s/(\"version\"[[:space:]]*:[[:space:]]*)\"[^"]*\"/\1\"${new_version}\"/" "$JSON_FILE"
+sed -i -E "s/(\"versionCode\"[[:space:]]*:[[:space:]]*)\"[^"]*\"/\1\"${new_increment}\"/" "$JSON_FILE"
+
+# Build module zip
+bash build-tools/build-create-module.sh
+
+# Commit and tag
+git add "$PROP_FILE" "$JSON_FILE"
+ git commit -m "chore: release ${new_version}" && git tag "v${new_version}"
+


### PR DESCRIPTION
## Summary
- add a script to bump version numbers, build and commit a release
- automate GitHub release creation when pushing a version tag

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862beda47008325a8fea759a82d0caa