### PR TITLE
Release 2025.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,15 @@
 
 ### New version available 
 
-Version: 2024.2
+Version: 2025.1
 
 Check [module github page](https://github.com/supermarsx/magisk-samsung-dex-standalone-mode)
 
 ## Changelog:
+
+2025.1
+- Add release automation script
+- Resolve shellcheck warnings
 
 2024.2
 - Build/debug scripts restructured

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=samsung-dex-standalone-mode
 name=Samsung DeX standalone mode
-version=2024.2
-versionCode=2
+version=2025.1
+versionCode=3
 author=supermarsx
 description=Patch `floating_feature.xml` to enable Samsung Dex standalone mode, available on devices supporting at least one Dex mode.
 updateJson=https://raw.githubusercontent.com/supermarsx/magisk-samsung-dex-standalone-mode/main/update.json

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,10 @@ Thanks to @WilsonBradley and @foxypiratecove37350 for their questions, adapted f
 
 ## Changelog
 
+2025.1
+- Add release automation script
+- Resolve shellcheck warnings
+
 2024.2
 - Build/debug scripts restructured
 - Module status bug fix, kept adding onto olders statuses on reboot

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-    "version": "2024.2",
-    "versionCode": "2",
+    "version": "2025.1",
+    "versionCode": "3",
     "zipUrl": "https://github.com/supermarsx/magisk-samsung-dex-standalone-mode/releases/latest/download/magisk-samsung-dex-standalone-mode.zip",
     "changelog": "https://raw.githubusercontent.com/supermarsx/magisk-samsung-dex-standalone-mode/main/changelog.md"
 }


### PR DESCRIPTION
## Summary
- bump version to 2025.1
- record new changes in changelog and readme
- update module metadata

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862c43d3ba883258acfb16326cc3e89