### PR TITLE
Fix test references for moved debug-unmount script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,12 +50,12 @@ A `Makefile` is also provided for convenience with the targets:
 
 Testing/debug related:
 
-`build-tools/debug-unmount.sh` - Simple unmount script.
+`debug/debug-unmount.sh` - Simple unmount script.
 
 Run it after testing the module to unmount the patched file:
 
 ```bash
-sh build-tools/debug-unmount.sh
+sh debug/debug-unmount.sh
 ```
 
 Every boot `post-fs-data.log` a new log file is generated with debugging information, existing log file is always overwritten keeping space footprint small. It's usually located inside the modules folder `/data/adb/modules/samsung-dex-standalone-mode`.
@@ -64,7 +64,7 @@ Every boot `post-fs-data.log` a new log file is generated with debugging informa
 
 Run `make build` from the repository root to create `magisk-samsung-dex-standalone-mode.zip` using the paths listed in `build-tools/build-filelist.txt`.
 Use `make clean` to remove a previously generated ZIP.
-During development `build-tools/debug-unmount.sh` can be used to unmount the patched file.
+During development `debug/debug-unmount.sh` can be used to unmount the patched file.
 
 
 Check `floating_feature.xml` file values by using `su` and then `cat /system/etc/floating_feature.xml` using your preferred terminal interface.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -35,8 +35,8 @@ sed '$d' post-fs-data.sh > /tmp/pfsd.sh
 sed '$d' customize.sh > /tmp/customize.sh
 # shellcheck source=customize.sh
 . /tmp/customize.sh
-sed '$d' build-tools/debug-unmount.sh > /tmp/debug-unmount.sh
-# shellcheck source=build-tools/debug-unmount.sh
+sed '$d' debug/debug-unmount.sh > /tmp/debug-unmount.sh
+# shellcheck source=debug/debug-unmount.sh
 . /tmp/debug-unmount.sh
 # Re-source post-fs-data functions to override debug replacements
 # shellcheck source=post-fs-data.sh

--- a/tests/test-build-create-module.ps1
+++ b/tests/test-build-create-module.ps1
@@ -8,7 +8,6 @@ Set-Location "$TmpDir\repo"
 
 # Provide required files for build script
 Copy-Item build-tools\build-filelist.txt build-filelist.txt
-Copy-Item build-tools\debug-unmount.sh debug-unmount.sh
 
 cmd /c build-tools\build-create-module.bat
 
@@ -28,7 +27,7 @@ $RequiredPaths = @(
     'module.prop',
     'post-fs-data.sh',
     'skip_mount',
-    'debug-unmount.sh',
+    'debug/debug-unmount.sh',
     'update.json'
 )
 foreach ($path in $RequiredPaths) {

--- a/tests/test-build-create-module.sh
+++ b/tests/test-build-create-module.sh
@@ -8,7 +8,6 @@ cd "$TMPDIR/repo"
 
 # Provide required files for build script
 ln -s build-tools/build-filelist.txt build-filelist.txt
-ln -s build-tools/debug-unmount.sh debug-unmount.sh
 
 bash build-tools/build-create-module.sh
 
@@ -28,7 +27,7 @@ required_paths=(
   "module.prop"
   "post-fs-data.sh"
   "skip_mount"
-  "debug-unmount.sh"
+  "debug/debug-unmount.sh"
   "update.json"
 )
 


### PR DESCRIPTION
## Summary
- update documentation and tests to use `debug/debug-unmount.sh`
- ensure tests search for the correct zipped path

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862f7fbeb78832595b539d5d0b75a08