### PR TITLE
Dynamic Path Detection for System-as-Root Support

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -12,7 +12,16 @@
 module_name="samsung-dex-standalone-mode"
 module_path="/data/adb/modules"
 floating_feature_xml_file="floating_feature.xml"
-floating_feature_xml_dir="/system/etc/"
+
+# Check for correct floating_feature.xml path
+if [ -f "/system/vendor/etc/floating_feature.xml" ]; then
+    floating_feature_xml_dir="/system/vendor/etc/"
+elif [ -f "/vendor/etc/floating_feature.xml" ]; then
+    floating_feature_xml_dir="/vendor/etc/"
+else
+    floating_feature_xml_dir="/system/etc/"
+fi
+
 floating_feature_xml_fullpath="$floating_feature_xml_dir$floating_feature_xml_file"
 floating_feature_xml_dex_key="SEC_FLOATING_FEATURE_COMMON_CONFIG_DEX_MODE"
 floating_feature_xml_dex_key_value="standalone"

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -8,7 +8,16 @@ module_log_file_fullpath="$module_dir$module_log_file"
 module_prop_file="module.prop"
 module_prop_fullpath="$module_dir$module_prop_file"
 floating_feature_xml_file="floating_feature.xml"
-floating_feature_xml_dir="/system/etc/"
+
+# Check for correct floating_feature.xml path
+if [ -f "/system/vendor/etc/floating_feature.xml" ]; then
+    floating_feature_xml_dir="/system/vendor/etc/"
+elif [ -f "/vendor/etc/floating_feature.xml" ]; then
+    floating_feature_xml_dir="/vendor/etc/"
+else
+    floating_feature_xml_dir="/system/etc/"
+fi
+
 floating_feature_xml_fullpath="$floating_feature_xml_dir$floating_feature_xml_file"
 floating_feature_xml_dex_key="SEC_FLOATING_FEATURE_COMMON_CONFIG_DEX_MODE"
 floating_feature_xml_dex_key_value="standalone"


### PR DESCRIPTION
This PR resolves an issue where the module fails to locate floating_feature.xml on Samsung devices using a "System-as-root" partition layout (notably the Galaxy S9, S10, and Note 9 series).

The previous logic hardcoded the path to /system/etc/. This resulted in a "file not found" error during installation and a fileexists failed error in Magisk after booting.

Verified working on a rooted Samsung Galaxy S9 (SM-G960F) running Android 10 (One UI 2.5).

Fixes #57 